### PR TITLE
add  floating point example to range() documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,13 @@ merge([[1], [2, 3]]); // returns [1, 2, 3]
 
 <a name="range" href="#range">#</a> <b>range</b>([<i>start</i>, ]<i>stop</i>[, <i>step</i>])
 
-Generates an array containing an arithmetic progression, similar to the Python built-in [range](http://docs.python.org/library/functions.html#range). This method is often used to iterate over a sequence of numeric or integer values, such as the indexes into an array. Unlike the Python version, the arguments are not required to be integers, though the results are more predictable if they are due to floating point precision.
+Generates an array containing an arithmetic progression, similar to the Python built-in [range](http://docs.python.org/library/functions.html#range). This method is often used to iterate over a sequence of numeric or integer values, such as the indexes into an array. Unlike the Python version, the arguments are not required to be integers, though the results are more predictable if they are due to floating point precision. For example, if the generated array is required to have a predictable length, consider using the array.map method on an integer range:
+
+```js
+var unexpected_length = d3.range(0, 1, 1/49).length; // returns 50
+
+var expected_length = d3.range(0, 49).map(function(d) { return 0 + d * 1/49; }).length; // returns 49
+```
 
 If *step* is omitted, it defaults to 1. If *start* is omitted, it defaults to 0. The *stop* value is not included in the result. The full form returns an array of numbers [*start*, *start* + *step*, *start* + 2 \* *step*, …]. If *step* is positive, the last element is the largest *start* + *i* \* *step* less than *stop*; if *step* is negative, the last element is the smallest *start* + *i* \* *step* greater than *stop*. If the returned array would contain an infinite number of values, an empty range is returned.
 


### PR DESCRIPTION
Illustrate floating point precision issue with example range and suggest using .map on integer range instead. See issue #5 .