### PR TITLE
Rename {map,set}.forEach to {map,set}.each.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Returns an array of values for every entry in this map. The order of the returne
 
 Returns an array of key-value objects for each entry in this map. The order of the returned entries is arbitrary. Each entry’s key is a string, but the value has arbitrary type.
 
-<a name="map_forEach" href="#map_forEach">#</a> <i>map</i>.<b>forEach</b>(<i>function</i>)
+<a name="map_each" href="#map_each">#</a> <i>map</i>.<b>each</b>(<i>function</i>)
 
 Calls the specified *function* for each entry in this map, passing the entry's key and value as two arguments. The `this` context of the *function* is this map. Returns undefined. The iteration order is arbitrary.
 
@@ -321,7 +321,7 @@ Returns an array of the string values in this set. The order of the returned val
 set(["foo", "bar", "foo", "baz"]).values(); // "foo", "bar", "baz"
 ```
 
-<a name="set_forEach" href="#set_forEach">#</a> <i>set</i>.<b>forEach</b>(<i>function</i>)
+<a name="set_each" href="#set_each">#</a> <i>set</i>.<b>each</b>(<i>function</i>)
 
 Calls the specified *function* for each value in this set, passing the value as an argument. The `this` context of the *function* is this set. Returns undefined. The iteration order is arbitrary.
 

--- a/src/map.js
+++ b/src/map.js
@@ -40,7 +40,7 @@ Map.prototype = map.prototype = {
     for (var property in this) if (property[0] === prefix) return false;
     return true;
   },
-  forEach: function(f) {
+  each: function(f) {
     for (var property in this) if (property[0] === prefix) f.call(this, property.slice(1), this[property]);
   }
 };
@@ -49,7 +49,7 @@ function map(object, f) {
   var map = new Map;
 
   // Copy constructor.
-  if (object instanceof Map) object.forEach(function(key, value) { map.set(key, value); });
+  if (object instanceof Map) object.each(function(key, value) { map.set(key, value); });
 
   // Index array by numeric index or specified key function.
   else if (Array.isArray(object)) {

--- a/src/map.js
+++ b/src/map.js
@@ -41,7 +41,7 @@ Map.prototype = map.prototype = {
     return true;
   },
   each: function(f) {
-    for (var property in this) if (property[0] === prefix) f.call(this, property.slice(1), this[property]);
+    for (var property in this) if (property[0] === prefix) f.call(this, this[property], property.slice(1));
   }
 };
 
@@ -49,7 +49,7 @@ function map(object, f) {
   var map = new Map;
 
   // Copy constructor.
-  if (object instanceof Map) object.each(function(key, value) { map.set(key, value); });
+  if (object instanceof Map) object.each(function(value, key) { map.set(key, value); });
 
   // Index array by numeric index or specified key function.
   else if (Array.isArray(object)) {

--- a/src/nest.js
+++ b/src/nest.js
@@ -30,7 +30,7 @@ export default function() {
       }
     }
 
-    valuesByKey.each(function(key, values) {
+    valuesByKey.each(function(values, key) {
       setResult(result, key, apply(values, depth, createResult, setResult));
     });
 
@@ -43,7 +43,7 @@ export default function() {
     var array = [],
         sortKey = sortKeys[depth++];
 
-    map.each(function(key, value) {
+    map.each(function(value, key) {
       array.push({key: key, values: entries(value, depth)});
     });
 

--- a/src/nest.js
+++ b/src/nest.js
@@ -30,7 +30,7 @@ export default function() {
       }
     }
 
-    valuesByKey.forEach(function(key, values) {
+    valuesByKey.each(function(key, values) {
       setResult(result, key, apply(values, depth, createResult, setResult));
     });
 
@@ -43,7 +43,7 @@ export default function() {
     var array = [],
         sortKey = sortKeys[depth++];
 
-    map.forEach(function(key, value) {
+    map.each(function(key, value) {
       array.push({key: key, values: entries(value, depth)});
     });
 

--- a/src/set.js
+++ b/src/set.js
@@ -15,7 +15,7 @@ Set.prototype = set.prototype = {
   values: proto.keys,
   size: proto.size,
   empty: proto.empty,
-  forEach: function(f) {
+  each: function(f) {
     for (var property in this) if (property[0] === prefix) f.call(this, property.slice(1));
   }
 };

--- a/test/map-test.js
+++ b/test/map-test.js
@@ -109,10 +109,10 @@ tape("map.empty() returns true only if the map is empty", function(test) {
   test.end();
 });
 
-tape("map.each(callback) passes key and value", function(test) {
+tape("map.each(callback) passes value and key", function(test) {
   var m = arrays.map({foo: 1, bar: "42"}),
       c = [];
-  m.each(function(k, v) { c.push([k, v]); });
+  m.each(function(v, k) { c.push([k, v]); });
   c.sort(function(a, b) { return a[0].localeCompare(b[0]); });
   test.deepEqual(c, [["bar", "42"], ["foo", 1]]);
   test.end();
@@ -133,8 +133,8 @@ tape("map.each(callback) iterates in arbitrary order", function(test) {
       m2 = arrays.map({bar: "42", foo: 1}),
       c1 = [],
       c2 = [];
-  m1.each(function(k, v) { c1.push([k, v]); });
-  m2.each(function(k, v) { c2.push([k, v]); });
+  m1.each(function(v, k) { c1.push([k, v]); });
+  m2.each(function(v, k) { c2.push([k, v]); });
   c1.sort(function(a, b) { return a[0].localeCompare(b[0]); });
   c2.sort(function(a, b) { return a[0].localeCompare(b[0]); });
   test.deepEqual(c1, c2);

--- a/test/map-test.js
+++ b/test/map-test.js
@@ -109,32 +109,32 @@ tape("map.empty() returns true only if the map is empty", function(test) {
   test.end();
 });
 
-tape("map.forEach(callback) passes key and value", function(test) {
+tape("map.each(callback) passes key and value", function(test) {
   var m = arrays.map({foo: 1, bar: "42"}),
       c = [];
-  m.forEach(function(k, v) { c.push([k, v]); });
+  m.each(function(k, v) { c.push([k, v]); });
   c.sort(function(a, b) { return a[0].localeCompare(b[0]); });
   test.deepEqual(c, [["bar", "42"], ["foo", 1]]);
   test.end();
 });
 
-tape("map.forEach(callback) uses the map as the context", function(test) {
+tape("map.each(callback) uses the map as the context", function(test) {
   var m = arrays.map({foo: 1, bar: "42"}),
       c = [];
-  m.forEach(function() { c.push(this); });
+  m.each(function() { c.push(this); });
   test.strictEqual(c[0], m);
   test.strictEqual(c[1], m);
   test.equal(c.length, 2);
   test.end();
 });
 
-tape("map.forEach(callback) iterates in arbitrary order", function(test) {
+tape("map.each(callback) iterates in arbitrary order", function(test) {
   var m1 = arrays.map({foo: 1, bar: "42"}),
       m2 = arrays.map({bar: "42", foo: 1}),
       c1 = [],
       c2 = [];
-  m1.forEach(function(k, v) { c1.push([k, v]); });
-  m2.forEach(function(k, v) { c2.push([k, v]); });
+  m1.each(function(k, v) { c1.push([k, v]); });
+  m2.each(function(k, v) { c2.push([k, v]); });
   c1.sort(function(a, b) { return a[0].localeCompare(b[0]); });
   c2.sort(function(a, b) { return a[0].localeCompare(b[0]); });
   test.deepEqual(c1, c2);

--- a/test/set-test.js
+++ b/test/set-test.js
@@ -59,32 +59,32 @@ tape("set.empty() returns true only if the set is empty", function(test) {
   test.end();
 });
 
-tape("set.forEach(callback) passes value", function(test) {
+tape("set.each(callback) passes value", function(test) {
   var s = arrays.set(["foo", "bar"]),
       c = [];
-  s.forEach(function(v) { c.push(v); });
+  s.each(function(v) { c.push(v); });
   c.sort();
   test.deepEqual(c, ["bar", "foo"]);
   test.end();
 });
 
-tape("set.forEach(callback) uses the set as the context", function(test) {
+tape("set.each(callback) uses the set as the context", function(test) {
   var s = arrays.set(["foo", "bar"]),
       c = [];
-  s.forEach(function() { c.push(this); });
+  s.each(function() { c.push(this); });
   test.strictEqual(c[0], s);
   test.strictEqual(c[1], s);
   test.equal(c.length, 2);
   test.end();
 });
 
-tape("set.forEach(callback) iterates in arbitrary order", function(test) {
+tape("set.each(callback) iterates in arbitrary order", function(test) {
   var s1 = arrays.set(["foo", "bar"]),
       s2 = arrays.set(["bar", "foo"]),
       c1 = [],
       c2 = [];
-  s1.forEach(function(v) { c1.push(v); });
-  s2.forEach(function(v) { c2.push(v); });
+  s1.each(function(v) { c1.push(v); });
+  s2.each(function(v) { c2.push(v); });
   c1.sort();
   c2.sort();
   test.deepEqual(c1, c2);


### PR DESCRIPTION
D3’s map.forEach method didn’t behave like ES6’s map.forEach anyway, because the order of arguments was reversed and it didn’t take a thisArg. So we might as well use our preferred name and make the API difference more apparent.

Related #12 #13.